### PR TITLE
大佬，发现您的项目引入了org.hibernate:hibernate-core@4.1.6.Final组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.ben</groupId>
   <artifactId>ITDict</artifactId>
@@ -29,7 +29,7 @@
 		<ehcache.version>2.6.6</ehcache.version>
 		<guava.version>15.0</guava.version>
 		<h2.version>1.3.166</h2.version>
-		<hibernate.version>4.1.6.Final</hibernate.version>
+		<hibernate.version>5.4.24.Final</hibernate.version>
 		<itext.version>2.1.7</itext.version>
 		<iTextAsian.version>2.1</iTextAsian.version>
 		<jackson.version>1.9.9</jackson.version>


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：Red Hat Hibernate ORM SQL注入漏洞
缺陷组件：org.hibernate:hibernate-core@4.1.6.Final
漏洞编号：CVE-2020-25638
漏洞描述：Red Hat Hibernate ORM是美国红帽（Red Hat）公司的一款用于编写应用程序的对象/关系映射（ORM）框架。
Hibernate ORM 存在SQL注入漏洞，攻击者可利用该漏洞通过Hibernate ORM的注释使用SQL注入来读取或修改数据。
影响范围：(∞, 5.4.24.Final)
最小修复版本：5.4.24.Final
缺陷组件引入路径：com.ben:ITDict@0.0.1-SNAPSHOT->org.hibernate:hibernate-core@4.1.6.Final
```
另外我运行这个项目时，IDE的安全插件提示还有32个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=pb5d78